### PR TITLE
Refactor FDFireflyIceManager discover delegate

### DIFF
--- a/Android/Libraries/fireflydevice/src/main/java/com/fireflydesign/fireflydevice/FDFireflyIceManager.java
+++ b/Android/Libraries/fireflydevice/src/main/java/com/fireflydesign/fireflydevice/FDFireflyIceManager.java
@@ -15,28 +15,18 @@ import android.bluetooth.le.ScanResult;
 import android.os.ParcelUuid;
 
 public class FDFireflyIceManager {
-    private enum DelegateType { DEVICE, RESULT }
-
-    public interface AbstractDelegate {
-    }
-
-    public interface Delegate extends AbstractDelegate {
-        void discovered(FDFireflyIceManager manager, BluetoothDevice device);
-    }
-
-    public interface ResultDelegate extends AbstractDelegate {
+    public interface Delegate {
         void discovered(FDFireflyIceManager manager, ScanResult result);
     }
 
     Activity activity;
     BluetoothAdapter bluetoothAdapter;
     UUID serviceUUID;
-    DelegateType delegateType;
-    AbstractDelegate delegate;
+    Delegate delegate;
 
     ScanCallback scanCallback;
 
-    public FDFireflyIceManager(final Activity activity, BluetoothAdapter bluetoothAdapter, UUID serviceUUID, AbstractDelegate delegate) {
+    public FDFireflyIceManager(final Activity activity, BluetoothAdapter bluetoothAdapter, UUID serviceUUID, Delegate delegate) {
         this.activity = activity;
         this.bluetoothAdapter = bluetoothAdapter;
         this.serviceUUID = serviceUUID;
@@ -66,16 +56,6 @@ public class FDFireflyIceManager {
         };
     }
 
-    public FDFireflyIceManager(final Activity activity, BluetoothAdapter bluetoothAdapter, UUID serviceUUID, Delegate delegate) {
-        this(activity, bluetoothAdapter, serviceUUID, (AbstractDelegate) delegate);
-        this.delegateType = DelegateType.DEVICE;
-    }
-
-    public FDFireflyIceManager(final Activity activity, BluetoothAdapter bluetoothAdapter, UUID serviceUUID, ResultDelegate delegate) {
-        this(activity, bluetoothAdapter, serviceUUID, (AbstractDelegate) delegate);
-        this.delegateType = DelegateType.RESULT;
-    }
-
     public void setDiscovery(boolean discover) {
         BluetoothLeScanner bluetoothLeScanner = bluetoothAdapter.getBluetoothLeScanner();
         if (discover) {
@@ -100,16 +80,6 @@ public class FDFireflyIceManager {
     }
 
     void discovered(ScanResult result) {
-        switch (this.delegateType) {
-            case DEVICE:
-                ((Delegate) delegate).discovered(this, result.getDevice());
-                break;
-
-            case RESULT:
-                ((ResultDelegate) delegate).discovered(this, result);
-
-            default:
-                break;
-        }
+        delegate.discovered(this, result);
     }
 }


### PR DESCRIPTION
I've refactored the way FDFireflyIceManager discovered delegate works to support multiple signatures for the discovered method. I tried to make the interface as extensible as possible while keeping it backwards compatible with anything implementing FDFireflyIceManager.Delegate. I did this by 
- defining an AbstractDelegate without any methods
- having other delegates extend this
- defining a DelegateType enum to make checks easy
- defining a constructor for each delegate type
- storing the actual delegate as an instance variable with type AbstractDelegate and then casting before calling the delegates discovered method with the appropriate args
- storing the delegateType as an instance variable (since we know this in the constructor).

There are a few warts
1. It is possible for the caller to implement FDFireflyIceManager.AbstractDelegate, which means discovered is essentially a noop
2. The names aren't very explicit, it would probably be better to break code at some future data and name them something like AbstractDelegate, DeviceDelegate, and ResultDelegate or some such. 
