### PR TITLE
check if json can be deserialized before writing to file

### DIFF
--- a/MacOSX/Firefly Activity Access/python/activity/cloudkit.py
+++ b/MacOSX/Firefly Activity Access/python/activity/cloudkit.py
@@ -48,6 +48,7 @@ class CloudKit:
         auth = CloudKitAuth(key_id=self.key_id, key_file_name=self.private_key_path)
         download_response = requests.get(download_url, auth=auth)
         download_response.raise_for_status()
+        json.loads(download_response.content)
         content = download_response.content
         directory = os.path.dirname(path)
         if not os.path.exists(directory):


### PR DESCRIPTION
Getting a new exception:
```.... 
"firefly-ice-api/MacOSX/Firefly Activity Access/python/activity/datastore.py", line 124, in list
    item = json.loads(line)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)```

Looks like requests is returning a 200 status code with content being an empty string. Calling json.loads() on download_response.content will throw an exception before trying to write content to a file that can't be deserialized, thus preventing this JSONDecodeError when calling datastore.Datastore.list()